### PR TITLE
Add scraping for Ranzy Locker

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The following leak sites are (planned to be) supported:
 - [ ] Cuba
 - [ ] Pay2Key
 - [ ] Astro Team
-- [ ] Ranzy Locker
+- [X] Ranzy Locker
 - [ ] LV
 
 If there are other leak sites you want implemented, feel free to open a PR or DM me on Twitter, [@captainGeech42](https://twitter.com/captainGeech42)

--- a/config_vol/config.sample.yaml
+++ b/config_vol/config.sample.yaml
@@ -6,6 +6,7 @@ sites:
   avaddon: http://something.onion
   darkside: http://something.onion
   babuk: http://something.onion
+  ranzy: http://something.onion
 
 # slack webhooks
 notifications:

--- a/src/ransomwatch.py
+++ b/src/ransomwatch.py
@@ -26,7 +26,8 @@ def main(argv):
         sites.Conti,
         sites.DarkSide,
         sites.REvil,
-        sites.Babuk
+        sites.Babuk,
+        sites.Ranzy
     ]
 
     logging.info(f"Found {len(sites_to_analyze)} sites")

--- a/src/sites/__init__.py
+++ b/src/sites/__init__.py
@@ -3,3 +3,4 @@ from .conti import Conti
 from .darkside import DarkSide
 from .revil import REvil
 from .babuk import Babuk
+from .ranzy import Ranzy

--- a/src/sites/ranzy.py
+++ b/src/sites/ranzy.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+import logging
+
+from bs4 import BeautifulSoup
+
+from db.models import Victim
+from net.proxy import Proxy
+from .sitecrawler import SiteCrawler
+
+
+class Ranzy(SiteCrawler):
+    actor = "Ranzy"
+
+    def scrape_victims(self):
+        with Proxy() as p:
+            r = p.get(f"{self.url}", headers=self.headers)
+
+            soup = BeautifulSoup(r.content.decode(), "html.parser")
+
+            # get max page number
+            victim_list = soup.find_all("div", class_="col py-3")
+
+            for victim in victim_list:
+                victim_name = victim.find("h3", class_="mb-3").text.strip()
+
+                # Not reliable but seems like this is how they include the link to victim's data
+                try:
+                    victim_leak_site = victim.find("a").attrs["href"]
+                except:
+                    victim_leak_site = None
+                
+                q = self.session.query(Victim).filter_by(
+                    url=victim_leak_site, site=self.site)
+
+                if q.count() == 0:
+                    # new victim
+                    v = Victim(name=victim_name, url=victim_leak_site, published=None,
+                               first_seen=datetime.utcnow(), last_seen=datetime.utcnow(), site=self.site)
+                    self.session.add(v)
+                    self.new_victims.append(v)
+                else:
+                    # already seen, update last_seen
+                    v = q.first()
+                    v.last_seen = datetime.utcnow()
+
+                # add the org to our seen list
+                self.current_victims.append(v)
+            self.session.commit()
+
+        self.site.last_scraped = datetime.utcnow()
+
+        # just for good measure
+        self.session.commit()


### PR DESCRIPTION
Scraping for Ranzy Locker. This is tested on Discord. The way they include the victim's link is kind of iffy, so hopefully they'll stay consistent with this method.