### PR TITLE
Add scraping to Ragnarok

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The following leak sites are (planned to be) supported:
 - [ ] Everest
 - [ ] Suncrypt
 - [ ] Ragnar_Locker
-- [ ] Ragnarok
+- [X] Ragnarok
 - [ ] Mount Locker
 - [X] BABUK LOCKER
 - [ ] RansomEXX

--- a/config_vol/config.sample.yaml
+++ b/config_vol/config.sample.yaml
@@ -6,7 +6,8 @@ sites:
   avaddon: http://something.onion
   darkside: http://something.onion
   babuk: http://something.onion
-
+  ragnarok: http://something.onion
+  
 # slack webhooks
 notifications:
   dest1:

--- a/src/ransomwatch.py
+++ b/src/ransomwatch.py
@@ -26,7 +26,8 @@ def main(argv):
         sites.Conti,
         sites.DarkSide,
         sites.REvil,
-        sites.Babuk
+        sites.Babuk,
+        sites.Ragnarok
     ]
 
     logging.info(f"Found {len(sites_to_analyze)} sites")

--- a/src/sites/__init__.py
+++ b/src/sites/__init__.py
@@ -3,3 +3,4 @@ from .conti import Conti
 from .darkside import DarkSide
 from .revil import REvil
 from .babuk import Babuk
+from .ragnarok import Ragnarok

--- a/src/sites/ragnarok.py
+++ b/src/sites/ragnarok.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+import logging
+
+from bs4 import BeautifulSoup
+
+from db.models import Victim
+from net.proxy import Proxy
+from .sitecrawler import SiteCrawler
+
+
+class Ragnarok(SiteCrawler):
+    actor = "Ragnarok"
+
+    def _handle_page(self, body: str):
+        
+        soup = BeautifulSoup(body, "html.parser")
+        
+        victim_list = soup.find_all("div", class_="post-entry")
+        
+        for victim in victim_list:
+            victim_name = victim.find("div", class_="post-title").text.strip()
+            
+            published = victim.find("div", class_="post-time")
+            published_dt = datetime.strptime(
+                published.text.strip(), "%Y-%m-%d")
+            
+            victim_leak_site = self.url + victim.find("div", class_="post-title").find("a").attrs["href"]
+            
+            
+            q = self.session.query(Victim).filter_by(
+                url=victim_leak_site, site=self.site)
+
+            if q.count() == 0:
+                # new victim
+                v = Victim(name=victim_name, url=victim_leak_site, published=published_dt,
+                            first_seen=datetime.utcnow(), last_seen=datetime.utcnow(), site=self.site)
+                self.session.add(v)
+                self.new_victims.append(v)
+            else:
+                # already seen, update last_seen
+                v = q.first()
+                v.last_seen = datetime.utcnow()
+
+            # add the org to our seen list
+            self.current_victims.append(v)
+        self.session.commit()
+    
+    def scrape_victims(self):
+        with Proxy() as p:
+            r = p.get(f"{self.url}", headers=self.headers)
+            soup = BeautifulSoup(r.content.decode(), "html.parser")
+            
+            # find all pages
+            page_nav = soup.find_all("a", class_="page-number")
+            
+            site_list = []
+            site_list.append(self.url)
+            
+            for page in page_nav:
+                site_list.append(self.url + page.attrs["href"])
+            
+            # handle each page
+            for site in site_list:
+                r = p.get(site, headers=self.headers)
+                self._handle_page(r.content.decode())


### PR DESCRIPTION
## Describe the changes
Add scraping capability to Ragnarok site. The victims' names are shown in the form of their website based on how the threat actor displays them on the leak site. They also include the company's formal description, but since the descriptions all have different format, it would require manual parsing to extract the full company name.

## Related issue(s)
New site: Ragnarok #19

## How was it tested?
This was tested on Discord

## Checklist for a new scraper (delete if N/A)

- [X] The URL for the site is nowhere in the git history
- [X] The site is added to `config.sample.yaml`
- [X] There aren't any debug logging statements/etc.
- [X] The data going into the DB is properly parsed and is accurate