### PR TITLE
Add scraping for Suncrypt leak site

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following leak sites are (planned to be) supported:
 - [ ] CL0P
 - [ ] Nefilim
 - [ ] Everest
-- [ ] Suncrypt
+- [X] Suncrypt
 - [ ] Ragnar_Locker
 - [ ] Ragnarok
 - [ ] Mount Locker

--- a/config_vol/config.sample.yaml
+++ b/config_vol/config.sample.yaml
@@ -6,6 +6,7 @@ sites:
   avaddon: http://something.onion
   darkside: http://something.onion
   babuk: http://something.onion
+  suncrypt: http://something.onion
 
 # slack webhooks
 notifications:

--- a/src/ransomwatch.py
+++ b/src/ransomwatch.py
@@ -26,7 +26,8 @@ def main(argv):
         sites.Conti,
         sites.DarkSide,
         sites.REvil,
-        sites.Babuk
+        sites.Babuk,
+        sites.Suncrypt
     ]
 
     logging.info(f"Found {len(sites_to_analyze)} sites")

--- a/src/sites/__init__.py
+++ b/src/sites/__init__.py
@@ -3,3 +3,4 @@ from .conti import Conti
 from .darkside import DarkSide
 from .revil import REvil
 from .babuk import Babuk
+from .suncrypt import Suncrypt

--- a/src/sites/suncrypt.py
+++ b/src/sites/suncrypt.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+import logging
+
+from bs4 import BeautifulSoup
+
+from db.models import Victim
+from net.proxy import Proxy
+from .sitecrawler import SiteCrawler
+
+
+class Suncrypt(SiteCrawler):
+    actor = "Suncrypt"
+
+    def _handle_page(self, body: str):
+        soup = BeautifulSoup(body, "html.parser")
+        
+        victim_list = soup.find_all("div", class_="card mb-5")
+        
+        for victim in victim_list:
+            victim_name = victim.find("div", class_="title is-4").text.strip()
+
+            victim_leak_site = self.url + "/" + victim.find("div", class_="title is-4").find("a").attrs["href"]
+
+            q = self.session.query(Victim).filter_by(
+                url=victim_leak_site, site=self.site)
+
+            if q.count() == 0:
+                # new victim
+                v = Victim(name=victim_name, url=victim_leak_site, published=None,
+                            first_seen=datetime.utcnow(), last_seen=datetime.utcnow(), site=self.site)
+                self.session.add(v)
+                self.new_victims.append(v)
+            else:
+                # already seen, update last_seen
+                v = q.first()
+                v.last_seen = datetime.utcnow()
+
+            # add the org to our seen list
+            self.current_victims.append(v)
+        self.session.commit()
+    
+    def scrape_victims(self):
+        with Proxy() as p:
+            r = p.get(f"{self.url}", headers=self.headers)
+            soup = BeautifulSoup(r.content.decode(), "html.parser")
+
+            # find all pages
+            page_nav = soup.find_all("a", class_="pagination-link")
+
+            site_list = []
+
+            for page in page_nav:
+                site_list.append(self.url + "/" + page.attrs["href"])
+
+            for site in site_list:
+                r = p.get(site, headers=self.headers)
+                self._handle_page(r.content.decode()) 


### PR DESCRIPTION
## Describe the changes
Adding scraping capability for Suncrypt leak site.

## Related issue(s)
New site: Suncrypt #17

## How was it tested?
This was tested on Discord

## Checklist for a new scraper (delete if N/A)

- [X] The URL for the site is nowhere in the git history
- [X] The site is added to `config.sample.yaml`
- [X] There aren't any debug logging statements/etc.
- [X] The data going into the DB is properly parsed and is accurate