### PR TITLE
Lockbit scraper fixed (now uses playwright) #74

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
-FROM library/python:3.9-buster
+FROM library/python:3.10-bullseye
 
 COPY requirements.txt /
 
 RUN pip install -r /requirements.txt
+
+RUN playwright install chromium
+RUN playwright install-deps chromium
+
+# Some dependencies for playwright/chromium
+RUN apt-get install -y \
+    libwoff1 libopus0 libwebp6 libwebpdemux2 libenchant-2-2 libgudev-1.0-0 libsecret-1-0 libhyphen0 \
+    libgdk-pixbuf2.0-0 libegl1 libnotify4 libxslt1.1 libevent-2.1-7 libgles2 libxcomposite1 libatk1.0-0 \
+    libatk-bridge2.0-0 libepoxy0 libgtk-3-0 libharfbuzz-icu0 libnss3 libxss1 libasound2 fonts-noto-color-emoji libxtst6
 
 RUN mkdir /app
 COPY src /app/

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyyaml
 python-dateutil
 lxml
 dateparser
+playwright

--- a/src/sites/lockbit.py
+++ b/src/sites/lockbit.py
@@ -1,11 +1,13 @@
+import re
 from datetime import datetime
-import logging
-
 from bs4 import BeautifulSoup
 
 from db.models import Victim
 from net.proxy import Proxy
 from .sitecrawler import SiteCrawler
+from config import Config
+
+from playwright.sync_api import sync_playwright
 
 
 class Lockbit(SiteCrawler):
@@ -40,9 +42,18 @@ class Lockbit(SiteCrawler):
 
 
     def scrape_victims(self):
-        with Proxy() as p:
-            r = p.get(f"{self.url}", headers=self.headers)
-            soup = BeautifulSoup(r.content.decode(), "html.parser")
+        with sync_playwright() as p:
+            browser = p.chromium.launch(proxy={"server": f'socks://{Config["proxy"]["hostname"]}:{Config["proxy"]["socks_port"]}'})
+            page = browser.new_page()
+            page.set_extra_http_headers(self.headers) 
+            page.goto(self.url)
+            
+            welcome_page_countdown = re.findall(r"let counter = (\d)\s", page.content())
+            welcome_page_countdown = ((int(welcome_page_countdown[0]) * 1000) + 500) if len(welcome_page_countdown) > 0 else 10000 # 10s as a timeout fallback value
+            page.wait_for_timeout(welcome_page_countdown)
+            res = page.content()
+
+            soup = BeautifulSoup(res, "html.parser")
 
             # find all pages
             page_nav = soup.find_all("a", class_="page-numbers")
@@ -57,5 +68,8 @@ class Lockbit(SiteCrawler):
                     site_list.append(page.attrs["href"])
             
             for site in site_list:
-                r = p.get(site, headers=self.headers)
-                self._handle_page(r.content.decode()) 
+                page.goto(self.url)
+                r = page.content()
+                self._handle_page(r) 
+
+            browser.close()

--- a/src/sites/lockbit.py
+++ b/src/sites/lockbit.py
@@ -20,7 +20,7 @@ class Lockbit(SiteCrawler):
 
         for victim in victim_list:
             victim_name = victim.find("div", class_="post-title").text.strip()
-            victim_leak_site = victim.find("div", class_="post-block-body").find("a").attrs["href"]
+            victim_leak_site = f'{self.url}{victim.find("div", class_="post-block-body").find("a").attrs["href"]}'
             published_dt= datetime.now()
             q = self.session.query(Victim).filter_by(
                 url=victim_leak_site, site=self.site)
@@ -58,7 +58,6 @@ class Lockbit(SiteCrawler):
             # find all pages
             page_nav = soup.find_all("a", class_="page-numbers")
 
-            
             site_list = []
             site_list.append(self.url)
             
@@ -68,8 +67,10 @@ class Lockbit(SiteCrawler):
                     site_list.append(page.attrs["href"])
             
             for site in site_list:
-                page.goto(self.url)
+                page.goto(site)
                 r = page.content()
                 self._handle_page(r) 
 
             browser.close()
+            self.site.last_scraped = datetime.utcnow()
+


### PR DESCRIPTION
## Describe the changes

Lockbit 2.0 now uses a ddos protection mechanism hence the regular http get method is no longer working. 

As a workaround I have implemented the [playwright](https://playwright.dev/python/docs/intro) Microsoft library which behaves as if a proper browser did the request. 

Summary of the changes:

1. `lockbit.py`: replaced the use of requests by playwright
2. `requirements.txt`: added playwright
3. Dockerfile: added playwright chromium support as well as required libraries.

I have also upgraded at the top of the Dockerfile from `python3.9-buster` to `python3.10-bullseye`.

## Related issue(s)

It fixes Issue #74 

Note that the scraping engine for lockbit has been left untouched as it is still perfectly working. Only the web page retrieval method has been altered. 

## How was it tested?

- [x] `docker-compose build app` 
- [x] `docker-compose up --abort-on-container-exit`
- [x] Checked that Lockbit entries have been inserted into the database
